### PR TITLE
Show gold and party summary in city menu

### DIFF
--- a/lib/screens/city_menu_screen.dart
+++ b/lib/screens/city_menu_screen.dart
@@ -96,25 +96,22 @@ class CityMenuScreen extends StatelessWidget {
                             child: Text(l10n.partyTitle),
                           ),
                         ),
-                        for (final position in PartyPosition.values) ...[
-                          Builder(
-                            builder: (context) {
-                              final member =
-                                  charactersProvider.memberAt(position);
-                              return ListTile(
-                                dense: true,
-                                title: Text(_positionLabel(l10n, position)),
-                                subtitle: Text(
-                                  member == null
-                                      ? l10n.partySlotEmpty
-                                      : _memberLabel(l10n, member),
-                                ),
-                              );
-                            },
-                          ),
-                          if (position != PartyPosition.values.last)
-                            const Divider(height: 1),
-                        ],
+                        ...PartyPosition.values.expand((position) {
+                          final member = charactersProvider.memberAt(position);
+                          return [
+                            ListTile(
+                              dense: true,
+                              title: Text(_positionLabel(l10n, position)),
+                              subtitle: Text(
+                                member == null
+                                    ? l10n.partySlotEmpty
+                                    : _memberLabel(l10n, member),
+                              ),
+                            ),
+                            if (position != PartyPosition.values.last)
+                              const Divider(height: 1),
+                          ];
+                        }),
                       ],
                     ),
                   );


### PR DESCRIPTION
## Summary
- add gold display to city menu header
- show forward/middle/rear party assignment summary
- keep menu list layout intact

## Testing
- flutter test

Closes #23