### PR TITLE
Allow battles to spawn multiple enemies

### DIFF
--- a/lib/providers/tasks_provider.dart
+++ b/lib/providers/tasks_provider.dart
@@ -379,9 +379,8 @@ class TasksProvider extends ChangeNotifier {
       final enemy = Enemy(
         type: enemyType,
         isTelegraphing: false,
-        uuid: const Uuid().toString(),
-        id: vermelhaContext.random.nextInt(999999),
-        name: "Enemy",
+        uuid: const Uuid().v4(),
+        name: 'Enemy ${i + 1}',
         level: 1,
         maxHp: 100,
         hp: 100,


### PR DESCRIPTION
## Summary\n- generate 2-3 enemies per encounter\n- keep existing battle rule assignment per enemy\n\n## Testing\n- not run (not requested)\n\nRefs #32