### PR TITLE
Add character detail access from party screen

### DIFF
--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -52,6 +52,7 @@
   "partyPositionRear": "後衛",
   "partySlotEmpty": "未設定",
   "partyClearSlot": "外す",
+  "partyViewDetails": "詳細を見る",
   "partyIncomplete": "前衛・中衛・後衛の3人を設定してください",
   "inventoryCapacityLabel": "所持品 {current}/{max}",
   "@inventoryCapacityLabel": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -250,6 +250,12 @@ abstract class AppLocalizations {
   /// **'外す'**
   String get partyClearSlot;
 
+  /// No description provided for @partyViewDetails.
+  ///
+  /// In ja, this message translates to:
+  /// **'詳細を見る'**
+  String get partyViewDetails;
+
   /// No description provided for @partyIncomplete.
   ///
   /// In ja, this message translates to:

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -97,6 +97,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get partyClearSlot => '外す';
 
   @override
+  String get partyViewDetails => '詳細を見る';
+
+  @override
   String get partyIncomplete => '前衛・中衛・後衛の3人を設定してください';
 
   @override

--- a/lib/screens/party_screen.dart
+++ b/lib/screens/party_screen.dart
@@ -107,6 +107,7 @@ class PartyScreen extends StatelessWidget {
                         children: [
                           IconButton(
                             icon: const Icon(Icons.info_outline),
+                            tooltip: l10n.partyViewDetails,
                             onPressed: () {
                               Navigator.of(context).pushNamed(
                                 CharacterScreen.routeName,


### PR DESCRIPTION
## Summary\n- add a detail button in party formation list items that opens CharacterScreen\n\n## Testing\n- not run (not requested)\n\nRefs #34