### PR TITLE
Simplify gambit editing with inline pickers

### DIFF
--- a/lib/screens/edit_battle_rules_screen.dart
+++ b/lib/screens/edit_battle_rules_screen.dart
@@ -84,29 +84,44 @@ class _EditBattleRulesScreenState extends State<EditBattleRulesScreen> {
     );
   }
 
-  Future<void> _selectCondition(BattleRule battleRule) async {
-    final l10n = AppLocalizations.of(context)!;
-    final selected = await showModalBottomSheet<Condition>(
+  Future<T?> _showPicker<T>({
+    required Iterable<T> options,
+    required T selected,
+    required String Function(T) label,
+    required Object Function(T) key,
+  }) {
+    final selectedKey = key(selected);
+    return showModalBottomSheet<T>(
       context: context,
       builder: (context) {
         return SafeArea(
           child: ListView(
             children: [
-              for (final condition in getConditionList())
+              for (final option in options)
                 ListTile(
-                  key: ValueKey(condition.uuid),
-                  leading: battleRule.condition.uuid == condition.uuid
+                  key: ValueKey(key(option)),
+                  leading: key(option) == selectedKey
                       ? const Icon(Icons.check)
                       : null,
-                  title: Text(conditionLabel(l10n, condition)),
-                  onTap: () => Navigator.of(context).pop(condition),
+                  title: Text(label(option)),
+                  onTap: () => Navigator.of(context).pop(option),
                 ),
             ],
           ),
         );
       },
     );
-    if (selected == null) {
+  }
+
+  Future<void> _selectCondition(BattleRule battleRule) async {
+    final l10n = AppLocalizations.of(context)!;
+    final selected = await _showPicker<Condition>(
+      options: getConditionList(),
+      selected: battleRule.condition,
+      label: (condition) => conditionLabel(l10n, condition),
+      key: (condition) => condition.uuid,
+    );
+    if (!mounted || selected == null) {
       return;
     }
     setState(() {
@@ -126,27 +141,13 @@ class _EditBattleRulesScreenState extends State<EditBattleRulesScreen> {
         battleRule.condition.targetCategory == TargetCategory.any
             ? getTargetList()
             : getTargetListByCategory(battleRule.condition.targetCategory);
-    final selected = await showModalBottomSheet<Target>(
-      context: context,
-      builder: (context) {
-        return SafeArea(
-          child: ListView(
-            children: [
-              for (final target in targets)
-                ListTile(
-                  key: ValueKey(target.uuid),
-                  leading: battleRule.target.uuid == target.uuid
-                      ? const Icon(Icons.check)
-                      : null,
-                  title: Text(targetLabel(l10n, target)),
-                  onTap: () => Navigator.of(context).pop(target),
-                ),
-            ],
-          ),
-        );
-      },
+    final selected = await _showPicker<Target>(
+      options: targets,
+      selected: battleRule.target,
+      label: (target) => targetLabel(l10n, target),
+      key: (target) => target.uuid,
     );
-    if (selected == null) {
+    if (!mounted || selected == null) {
       return;
     }
     setState(() {
@@ -157,27 +158,13 @@ class _EditBattleRulesScreenState extends State<EditBattleRulesScreen> {
 
   Future<void> _selectAction(BattleRule battleRule) async {
     final l10n = AppLocalizations.of(context)!;
-    final selected = await showModalBottomSheet<Action>(
-      context: context,
-      builder: (context) {
-        return SafeArea(
-          child: ListView(
-            children: [
-              for (final action in getActionList())
-                ListTile(
-                  key: ValueKey(action.uuid),
-                  leading: battleRule.action.uuid == action.uuid
-                      ? const Icon(Icons.check)
-                      : null,
-                  title: Text(actionLabel(l10n, action)),
-                  onTap: () => Navigator.of(context).pop(action),
-                ),
-            ],
-          ),
-        );
-      },
+    final selected = await _showPicker<Action>(
+      options: getActionList(),
+      selected: battleRule.action,
+      label: (action) => actionLabel(l10n, action),
+      key: (action) => action.uuid,
     );
-    if (selected == null) {
+    if (!mounted || selected == null) {
       return;
     }
     setState(() {


### PR DESCRIPTION
## Summary\n- replace multi-screen selection with inline bottom-sheet pickers\n- keep condition/target/action edits on one screen\n\n## Testing\n- not run (not requested)\n\nCloses #63