### PR TITLE
Fix iOS device build failures

### DIFF
--- a/lib/models/party.dart
+++ b/lib/models/party.dart
@@ -17,7 +17,7 @@ class Party {
   }
 
   factory Party.fromRoster(List<PlayerCharacter> roster) {
-    final positions = {
+    final positions = <PartyPosition, int?>{
       for (final position in PartyPosition.values) position: null,
     };
     for (final member in roster) {

--- a/lib/screens/edit_battle_rules_screen.dart
+++ b/lib/screens/edit_battle_rules_screen.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Action;
 import 'package:provider/provider.dart';
 import 'package:vermelha_app/l10n/app_localizations.dart';
 import 'package:vermelha_app/l10n/model_localizations.dart';

--- a/lib/screens/select_target_screen.dart
+++ b/lib/screens/select_target_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:vermelha_app/l10n/app_localizations.dart';
 import 'package:vermelha_app/l10n/model_localizations.dart';
 import 'package:vermelha_app/models/battle_rule.dart';
+import 'package:vermelha_app/models/condition.dart';
 import 'package:vermelha_app/models/target.dart';
 
 class SelectTargetScreen extends StatefulWidget {


### PR DESCRIPTION
## 概要
- Xcode実機ビルド時のDartコンパイルエラーを解消
- `Action`の命名衝突回避、`TargetCategory`のimport追加、Mapの型明示

## テスト
- `xcodebuild -workspace ios/Runner.xcworkspace -scheme Runner -configuration Debug -sdk iphoneos -destination generic/platform=iOS build`

Closes #72