### PR TITLE
Implement target-only gambit rules

### DIFF
--- a/lib/l10n/model_localizations.dart
+++ b/lib/l10n/model_localizations.dart
@@ -168,6 +168,12 @@ String targetLabelByUuid(AppLocalizations l10n, String uuid) {
       return l10n.targetMatchingEnemy;
     case targetSelfId:
       return l10n.targetSelf;
+    case targetAllyHpBelow75Id:
+      return l10n.conditionAllyHpBelow75;
+    case targetAllyHpBelow50Id:
+      return l10n.conditionAllyHpBelow50;
+    case targetAllyHpBelow25Id:
+      return l10n.conditionAllyHpBelow25;
     case targetRandomAllyId:
       return l10n.targetRandomAlly;
     case targetRandomEnemyId:
@@ -220,6 +226,12 @@ String targetLabelByUuid(AppLocalizations l10n, String uuid) {
       return l10n.targetFirstEnemy;
     case targetAttackingEnemyId:
       return l10n.targetAttackingEnemy;
+    case targetEnemyTelegraphId:
+      return l10n.conditionEnemyTelegraph;
+    case targetEnemyIrregularId:
+      return l10n.conditionEnemyIrregularExists;
+    case targetEnemyRegularId:
+      return l10n.conditionEnemyRegularExists;
   }
   return l10n.unknownLabel;
 }

--- a/lib/models/battle_rule.dart
+++ b/lib/models/battle_rule.dart
@@ -1,15 +1,14 @@
 import 'package:vermelha_app/models/action.dart';
 import 'package:vermelha_app/models/character.dart';
 import 'package:vermelha_app/models/player_character.dart';
-import 'package:vermelha_app/models/condition.dart';
 import 'package:vermelha_app/models/target.dart';
+import 'package:vermelha_app/models/condition.dart';
 
 class BattleRule {
   final int? id;
   final Character owner;
   final int priority;
   final String name;
-  Condition condition;
   Target target;
   Action action;
 
@@ -18,27 +17,23 @@ class BattleRule {
     required this.owner,
     required this.priority,
     required this.name,
-    required this.condition,
     required this.target,
     required this.action,
   });
 
   static BattleRule fromJson(Map<String, dynamic> json, PlayerCharacter owner) {
-    Condition condition = getConditionByUuid(json['condition_uuid']);
     final targetUuid = json['target_uuid'] as String?;
-    Target target = targetUuid == null || targetUuid.isEmpty
-        ? getTargetListByCategory(condition.targetCategory).first
-        : getTargetByUuid(
-            targetUuid,
-            fallbackCategory: condition.targetCategory,
-          );
+    final conditionUuid = json['condition_uuid'] as String?;
+    final target = targetFromLegacyRule(
+      targetUuid: targetUuid,
+      conditionUuid: conditionUuid,
+    );
     Action action = getActionByUuid(json['action_uuid']);
     return BattleRule(
       id: json['id'],
       owner: owner,
       priority: json['priority'],
       name: json['name'],
-      condition: condition,
       target: target,
       action: action,
     );
@@ -50,7 +45,7 @@ class BattleRule {
       'owner_id': owner.id,
       'priority': priority,
       'name': name,
-      'condition_uuid': condition.uuid,
+      'condition_uuid': conditionAlwaysId,
       'target_uuid': target.uuid,
       'action_uuid': action.uuid,
     };
@@ -61,7 +56,6 @@ class BattleRule {
     PlayerCharacter? owner,
     int? priority,
     String? name,
-    Condition? condition,
     Target? target,
     Action? action,
   }) {
@@ -70,7 +64,6 @@ class BattleRule {
       owner: owner ?? this.owner,
       priority: priority ?? this.priority,
       name: name ?? this.name,
-      condition: condition ?? this.condition,
       target: target ?? this.target,
       action: action ?? this.action,
     );

--- a/lib/models/target.dart
+++ b/lib/models/target.dart
@@ -38,6 +38,17 @@ const String targetHighestSpeedAllyId = '2f9b7ad3-1a0f-4d75-9a9b-8d87d1f7b026';
 const String targetHighestSpeedEnemyId = '2f9b7ad3-1a0f-4d75-9a9b-8d87d1f7b027';
 const String targetFirstEnemyId = '2f9b7ad3-1a0f-4d75-9a9b-8d87d1f7b028';
 const String targetAttackingEnemyId = '2f9b7ad3-1a0f-4d75-9a9b-8d87d1f7b029';
+const String targetAllyHpBelow75Id = '43bdcfaa-3edf-4f46-89f8-434796afb930';
+const String targetAllyHpBelow50Id = '6b8a75d8-7324-41b1-95ed-dfe00023f9c4';
+const String targetAllyHpBelow25Id = '786f45ea-6221-4be7-8525-b8d74a1eaeef';
+const String targetEnemyTelegraphId = 'de920639-8e2e-44ef-b133-d92d00dc1a58';
+const String targetEnemyIrregularId = '03c67f83-f717-4fdf-83bf-d86fc5e85782';
+const String targetEnemyRegularId = '3a202f71-e259-44d0-974c-b93ab0559fa6';
+
+const Set<String> _legacyTargetIds = {
+  targetMatchingAllyId,
+  targetMatchingEnemyId,
+};
 
 class Target {
   final String uuid;
@@ -75,6 +86,22 @@ List<Character> _selectRandom(
   return [target];
 }
 
+List<Character> _selectFirstByHpThreshold(
+  List<Character> candidates,
+  double threshold,
+) {
+  if (candidates.isEmpty) {
+    return [];
+  }
+  candidates.sort((a, b) => a.hp.compareTo(b.hp));
+  for (final candidate in candidates) {
+    if (candidate.hp <= candidate.maxHp * threshold) {
+      return [candidate];
+    }
+  }
+  return [];
+}
+
 List<Target> getTargetList() {
   return [
     Target(
@@ -99,6 +126,27 @@ List<Target> getTargetList() {
         }
         return [];
       },
+    ),
+    Target(
+      uuid: targetAllyHpBelow75Id,
+      name: 'HPが75%以下の味方',
+      targetCategory: TargetCategory.ally,
+      selectTargets: (_, __, candidates) =>
+          _selectFirstByHpThreshold(candidates, 0.75),
+    ),
+    Target(
+      uuid: targetAllyHpBelow50Id,
+      name: 'HPが50%以下の味方',
+      targetCategory: TargetCategory.ally,
+      selectTargets: (_, __, candidates) =>
+          _selectFirstByHpThreshold(candidates, 0.5),
+    ),
+    Target(
+      uuid: targetAllyHpBelow25Id,
+      name: 'HPが25%以下の味方',
+      targetCategory: TargetCategory.ally,
+      selectTargets: (_, __, candidates) =>
+          _selectFirstByHpThreshold(candidates, 0.25),
     ),
     Target(
       uuid: '2f9b7ad3-1a0f-4d75-9a9b-8d87d1f7b004',
@@ -292,6 +340,45 @@ List<Target> getTargetList() {
         return [];
       },
     ),
+    Target(
+      uuid: targetEnemyTelegraphId,
+      name: '攻撃予兆の敵',
+      targetCategory: TargetCategory.enemy,
+      selectTargets: (_, __, candidates) {
+        return candidates
+            .where(
+              (candidate) =>
+                  candidate is Enemy && candidate.isTelegraphing,
+            )
+            .toList();
+      },
+    ),
+    Target(
+      uuid: targetEnemyIrregularId,
+      name: '非定型の敵',
+      targetCategory: TargetCategory.enemy,
+      selectTargets: (_, __, candidates) {
+        return candidates
+            .where(
+              (candidate) =>
+                  candidate is Enemy && candidate.type == EnemyType.irregular,
+            )
+            .toList();
+      },
+    ),
+    Target(
+      uuid: targetEnemyRegularId,
+      name: '定型の敵',
+      targetCategory: TargetCategory.enemy,
+      selectTargets: (_, __, candidates) {
+        return candidates
+            .where(
+              (candidate) =>
+                  candidate is Enemy && candidate.type == EnemyType.regular,
+            )
+            .toList();
+      },
+    ),
   ];
 }
 
@@ -307,7 +394,7 @@ Target getTargetByUuid(
   if (fallbackCategory != null) {
     return getTargetListByCategory(fallbackCategory).first;
   }
-  return getTargetList().first;
+  return getSelectableTargetList().first;
 }
 
 List<Target> getTargetListByCategory(TargetCategory category) {
@@ -317,4 +404,98 @@ List<Target> getTargetListByCategory(TargetCategory category) {
   return getTargetList()
       .where((target) => target.targetCategory == category)
       .toList();
+}
+
+List<Target> getSelectableTargetList() {
+  return getTargetList()
+      .where((target) => !_legacyTargetIds.contains(target.uuid))
+      .toList();
+}
+
+Target? mapConditionUuidToTarget(String? conditionUuid) {
+  switch (conditionUuid) {
+    case conditionLowestHpEnemyId:
+      return getTargetByUuid(targetLowestHpEnemyId);
+    case conditionHighestHpEnemyId:
+      return getTargetByUuid(targetHighestHpEnemyId);
+    case conditionRandomEnemyId:
+      return getTargetByUuid(targetRandomEnemyId);
+    case conditionRandomAllyId:
+      return getTargetByUuid(targetRandomAllyId);
+    case conditionAllEnemiesId:
+      return getTargetByUuid(targetAllEnemiesId);
+    case conditionAllAlliesId:
+      return getTargetByUuid(targetAllAlliesId);
+    case conditionEnemyTelegraphId:
+      return getTargetByUuid(targetEnemyTelegraphId);
+    case conditionEnemyIrregularExistsId:
+      return getTargetByUuid(targetEnemyIrregularId);
+    case conditionEnemyRegularExistsId:
+      return getTargetByUuid(targetEnemyRegularId);
+    case conditionAllyHpBelow75Id:
+      return getTargetByUuid(targetAllyHpBelow75Id);
+    case conditionAllyHpBelow50Id:
+      return getTargetByUuid(targetAllyHpBelow50Id);
+    case conditionAllyHpBelow25Id:
+      return getTargetByUuid(targetAllyHpBelow25Id);
+    case conditionLowestMpEnemyId:
+      return getTargetByUuid(targetLowestMpEnemyId);
+    case conditionHighestMpEnemyId:
+      return getTargetByUuid(targetHighestMpEnemyId);
+    case conditionLowestAttackEnemyId:
+      return getTargetByUuid(targetLowestAttackEnemyId);
+    case conditionHighestAttackEnemyId:
+      return getTargetByUuid(targetHighestAttackEnemyId);
+    case conditionLowestDefenseEnemyId:
+      return getTargetByUuid(targetLowestDefenseEnemyId);
+    case conditionHighestDefenseEnemyId:
+      return getTargetByUuid(targetHighestDefenseEnemyId);
+    case conditionLowestSpeedEnemyId:
+      return getTargetByUuid(targetLowestSpeedEnemyId);
+    case conditionHighestSpeedEnemyId:
+      return getTargetByUuid(targetHighestSpeedEnemyId);
+    case conditionLowestHpAllyId:
+      return getTargetByUuid(targetLowestHpAllyId);
+    case conditionHighestHpAllyId:
+      return getTargetByUuid(targetHighestHpAllyId);
+    case conditionLowestMpAllyId:
+      return getTargetByUuid(targetLowestMpAllyId);
+    case conditionHighestMpAllyId:
+      return getTargetByUuid(targetHighestMpAllyId);
+    case conditionLowestAttackAllyId:
+      return getTargetByUuid(targetLowestAttackAllyId);
+    case conditionHighestAttackAllyId:
+      return getTargetByUuid(targetHighestAttackAllyId);
+    case conditionLowestDefenseAllyId:
+      return getTargetByUuid(targetLowestDefenseAllyId);
+    case conditionHighestDefenseAllyId:
+      return getTargetByUuid(targetHighestDefenseAllyId);
+    case conditionLowestSpeedAllyId:
+      return getTargetByUuid(targetLowestSpeedAllyId);
+    case conditionHighestSpeedAllyId:
+      return getTargetByUuid(targetHighestSpeedAllyId);
+  }
+  return null;
+}
+
+Target targetFromLegacyRule({
+  String? targetUuid,
+  String? conditionUuid,
+}) {
+  if (targetUuid != null && targetUuid.isNotEmpty) {
+    if (targetUuid == targetMatchingAllyId) {
+      final mapped = mapConditionUuidToTarget(conditionUuid);
+      return mapped ?? getTargetByUuid(targetAllAlliesId);
+    }
+    if (targetUuid == targetMatchingEnemyId) {
+      final mapped = mapConditionUuidToTarget(conditionUuid);
+      return mapped ?? getTargetByUuid(targetAllEnemiesId);
+    }
+    return getTargetByUuid(targetUuid);
+  }
+  final mapped = mapConditionUuidToTarget(conditionUuid);
+  if (mapped != null) {
+    return mapped;
+  }
+  return getSelectableTargetList().first;
 }

--- a/lib/providers/tasks_provider.dart
+++ b/lib/providers/tasks_provider.dart
@@ -594,8 +594,7 @@ class TasksProvider extends ChangeNotifier {
           owner: enemy,
           priority: 1,
           name: "Enemy Rule",
-          condition: getConditionByUuid(conditionRandomAllyId),
-          target: getTargetListByCategory(TargetCategory.ally).first,
+          target: getTargetByUuid(targetRandomAllyId),
           action: getActionByUuid(actionPhysicalAttackId),
         )
       ];
@@ -661,12 +660,9 @@ class TasksProvider extends ChangeNotifier {
   }
 
   List<Character> _candidatesForRule(BattleRule rule) {
-    if (rule.condition.targetCategory == TargetCategory.any) {
-      return rule.target.targetCategory == TargetCategory.ally
-          ? vermelhaContext.allies
-          : vermelhaContext.enemies;
-    }
-    return rule.condition.getTargets(vermelhaContext);
+    return rule.target.targetCategory == TargetCategory.ally
+        ? vermelhaContext.allies
+        : vermelhaContext.enemies;
   }
 
   bool _canExecuteAction(Character actor, Action action) {

--- a/lib/repository/character_repository.dart
+++ b/lib/repository/character_repository.dart
@@ -3,6 +3,7 @@ import 'package:sqflite/sqflite.dart';
 
 import 'package:vermelha_app/db/db_connection.dart';
 import 'package:vermelha_app/models/battle_rule.dart';
+import 'package:vermelha_app/models/condition.dart';
 import 'package:vermelha_app/models/equipment_slot.dart';
 import 'package:vermelha_app/models/item.dart';
 import 'package:vermelha_app/models/item_catalog.dart';
@@ -128,7 +129,7 @@ class CharacterRepository {
           'owner_id': id,
           'priority': battleRule.priority,
           'name': battleRule.name,
-          'condition_uuid': battleRule.condition.uuid,
+          'condition_uuid': conditionAlwaysId,
           'target_uuid': battleRule.target.uuid,
           'action_uuid': battleRule.action.uuid,
         });
@@ -185,7 +186,7 @@ class CharacterRepository {
           'owner_id': character.id,
           'priority': battleRule.priority,
           'name': battleRule.name,
-          'condition_uuid': battleRule.condition.uuid,
+          'condition_uuid': conditionAlwaysId,
           'target_uuid': battleRule.target.uuid,
           'action_uuid': battleRule.action.uuid,
         });

--- a/lib/screens/select_condition_screen.dart
+++ b/lib/screens/select_condition_screen.dart
@@ -3,7 +3,6 @@ import 'package:vermelha_app/l10n/app_localizations.dart';
 import 'package:vermelha_app/l10n/model_localizations.dart';
 
 import 'package:vermelha_app/models/battle_rule.dart';
-import 'package:vermelha_app/models/condition.dart';
 import 'package:vermelha_app/models/target.dart';
 
 class SelectConditionScreen extends StatefulWidget {
@@ -39,22 +38,15 @@ class _SelectConditionScreenState extends State<SelectConditionScreen> {
                 key: _formKey,
                 child: ListView(
                   children: [
-                    for (var condition in getConditionList())
+                    for (var target in getSelectableTargetList())
                       ListTile(
-                        key: ValueKey(condition.uuid),
-                        leading: _battleRule!.condition.uuid == condition.uuid
+                        key: ValueKey(target.uuid),
+                        leading: _battleRule!.target.uuid == target.uuid
                             ? const Icon(Icons.check)
                             : null,
-                        title: Text(conditionLabel(l10n, condition)),
+                        title: Text(targetLabel(l10n, target)),
                         onTap: () {
-                          _battleRule!.condition = condition;
-                          if (condition.targetCategory != TargetCategory.any &&
-                              _battleRule!.target.targetCategory !=
-                                  condition.targetCategory) {
-                            _battleRule!.target =
-                                getTargetListByCategory(condition.targetCategory)
-                                    .first;
-                          }
+                          _battleRule!.target = target;
                           Navigator.of(context).pop();
                         },
                       ),

--- a/lib/screens/select_target_screen.dart
+++ b/lib/screens/select_target_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:vermelha_app/l10n/app_localizations.dart';
 import 'package:vermelha_app/l10n/model_localizations.dart';
 import 'package:vermelha_app/models/battle_rule.dart';
-import 'package:vermelha_app/models/condition.dart';
 import 'package:vermelha_app/models/target.dart';
 
 class SelectTargetScreen extends StatefulWidget {
@@ -24,9 +23,7 @@ class _SelectTargetScreenState extends State<SelectTargetScreen> {
       _battleRule = ModalRoute.of(context)!.settings.arguments as BattleRule;
     }
 
-    final targets = _battleRule!.condition.targetCategory == TargetCategory.any
-        ? getTargetList()
-        : getTargetListByCategory(_battleRule!.condition.targetCategory);
+    final targets = getSelectableTargetList();
 
     return Scaffold(
       appBar: AppBar(


### PR DESCRIPTION
## Summary\n- Remove Condition from active gambit rules and evaluation\n- Add target selectors for HP thresholds, telegraphing, and enemy types\n- Update battle rule loading/saving with legacy mapping\n- Simplify gambit editor to Target + Action\n\n## Issue\n- Closes #76\n