### PR TITLE
CI: build Flutter web and deploy to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,3 +31,25 @@ jobs:
         run: flutter test
       - name: Build APK (debug)
         run: flutter build apk --debug
+      - name: Build Web (release)
+        run: flutter build web --release --base-href "/${{ github.event.repository.name }}/"
+      - name: Upload GitHub Pages artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/web
+
+  deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: true
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add Flutter web build to CI
- upload `build/web` on main and deploy with GitHub Pages
- set web `base-href` to repo name for project pages

## Testing
- not run (CI only)

## Related
- Closes #97
