### PR TITLE
Update README for v1 overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,17 @@ flutter test
 
 ## ビルド
 ```bash
+# デバッグビルド
 flutter build apk --debug
 flutter build ios --no-codesign
+
+# リリースビルド（配布用）
+flutter build appbundle --release
+flutter build ipa --release
 ```
 
 ## ディレクトリ構成
 - `assets/`: 画像/フォントなどのアセット
 - `docs/`: 仕様書
 - `lib/`: アプリ本体
-- `lib/db/`: ローカル永続化（sqflite）
+  - `db/`: ローカル永続化（sqflite）


### PR DESCRIPTION
## Summary
- Replace template README with v1 overview and dev commands
- Link `docs/spec.md` as the canonical spec
- Add a short directory overview

## Testing
- Not run (docs-only change)

Closes #99
